### PR TITLE
retract all prior versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,11 @@ module github.com/blugnu/unilog4logrus
 
 go 1.18
 
-retract v1.0.0 // released with incorrect module name
+retract [v1.0.0, v1.1.2] // released with incorrect module name and/or incorrect retractions
 
 require (
 	github.com/blugnu/go-logspy v0.1.1
-	github.com/blugnu/unilog v1.1.2
+	github.com/blugnu/unilog v1.1.3
 	github.com/sirupsen/logrus v1.9.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/blugnu/go-errorcontext v0.1.0 h1:/VRIE4BIygFNq5vvf6Z+ZgdZP0JV7+GGOICG
 github.com/blugnu/go-errorcontext v0.1.0/go.mod h1:OB/kqD+3gkypupbcXPyWoPj5aVU5xfoymZfmMojh9mQ=
 github.com/blugnu/go-logspy v0.1.1 h1:jpu9E7IWr8GcUo6jbqQ9juaxORPiPLvgnmkTs72XU2o=
 github.com/blugnu/go-logspy v0.1.1/go.mod h1:E+PMio89HeNXJ8TLGXGS3XX7cFRFe0i8oOpCOBeBuz4=
-github.com/blugnu/unilog v1.1.2 h1:B9EnkL1/KXb2cZK9jtLadXW/Dm1MOWksDUBBNJ2ZOc8=
-github.com/blugnu/unilog v1.1.2/go.mod h1:OcDT8BG9BiIW70gclz4N16+hvxq8kVLIRprcObffOAQ=
+github.com/blugnu/unilog v1.1.3 h1:aEtKGEFnX5u0rWkCPP7SVrZHMZigLaPLbZ1W67LY6Zw=
+github.com/blugnu/unilog v1.1.3/go.mod h1:j8mAavXm9UbuwA8Za7zAgGW0hpctb8TTQF6HmI08ZWg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
all prior versions are retracted due to bugs and/or incorrect retractions

dependency on unilog updated to v1.1.3 as all prior versions of unilog are similarly retracted