### PR TITLE
update dependencies and replace blugnu/go-errorcontext with blugnu/errorcontext

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,6 @@
+name: go module release
+on: [ push, pull_request ]
+jobs:
+  module-qa:
+    uses: blugnu/.reusable/.github/workflows/module.yml@master
+    secrets: inherit

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,6 +1,0 @@
-name: qa
-on: [ push, pull_request ]
-jobs:
-  module-qa:
-    uses: blugnu/.reusable/.github/workflows/module-qa.yml@master
-    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center" style="margin-bottom:20px">
   <!-- <img src=".assets/banner.png" alt="logger" /> -->
   <div align="center">
-    <a href="https://github.com/blugnu/unilog4logrus/actions/workflows/qa.yml"><img alt="build-status" src="https://github.com/blugnu/unilog4logrus/actions/workflows/qa.yml/badge.svg?branch=master&style=flat-square"/></a>
+    <a href="https://github.com/blugnu/unilog4logrus/actions/workflows/pipeline.yml"><img alt="build-status" src="https://github.com/blugnu/unilog4logrus/actions/workflows/pipeline.yml/badge.svg?branch=master&style=flat-square"/></a>
     <a href="https://goreportcard.com/report/github.com/blugnu/unilog4logrus" ><img alt="go report" src="https://goreportcard.com/badge/github.com/blugnu/unilog4logrus"/></a>
     <a><img alt="go version >= 1.14" src="https://img.shields.io/github/go-mod/go-version/blugnu/unilog4logrus?style=flat-square"/></a>
     <a href="https://github.com/blugnu/unilog4logrus/blob/master/LICENSE"><img alt="MIT License" src="https://img.shields.io/github/license/blugnu/unilog4logrus?color=%234275f5&style=flat-square"/></a>

--- a/go.mod
+++ b/go.mod
@@ -1,16 +1,16 @@
 module github.com/blugnu/unilog4logrus
 
-go 1.18
+go 1.20
 
 retract [v1.0.0, v1.1.2] // released with incorrect module name and/or incorrect retractions
 
 require (
 	github.com/blugnu/go-logspy v0.1.1
-	github.com/blugnu/unilog v1.1.3
+	github.com/blugnu/unilog v1.1.4
 	github.com/sirupsen/logrus v1.9.3
 )
 
 require (
-	github.com/blugnu/go-errorcontext v0.1.0 // indirect
-	golang.org/x/sys v0.11.0 // indirect
+	github.com/blugnu/errorcontext v0.2.2 // indirect
+	golang.org/x/sys v0.14.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
-github.com/blugnu/go-errorcontext v0.1.0 h1:/VRIE4BIygFNq5vvf6Z+ZgdZP0JV7+GGOICGSlcDNL0=
-github.com/blugnu/go-errorcontext v0.1.0/go.mod h1:OB/kqD+3gkypupbcXPyWoPj5aVU5xfoymZfmMojh9mQ=
+github.com/blugnu/errorcontext v0.2.2 h1:TqFPGb0pdNWtACxvbLqqzD8fzZAoa2uXdjohgk8RRwU=
+github.com/blugnu/errorcontext v0.2.2/go.mod h1:4tMqaqNkRxLrL9d8EwWKZBbJMV+Zd8GLu+0Ih+QY3Ac=
 github.com/blugnu/go-logspy v0.1.1 h1:jpu9E7IWr8GcUo6jbqQ9juaxORPiPLvgnmkTs72XU2o=
 github.com/blugnu/go-logspy v0.1.1/go.mod h1:E+PMio89HeNXJ8TLGXGS3XX7cFRFe0i8oOpCOBeBuz4=
-github.com/blugnu/unilog v1.1.3 h1:aEtKGEFnX5u0rWkCPP7SVrZHMZigLaPLbZ1W67LY6Zw=
-github.com/blugnu/unilog v1.1.3/go.mod h1:j8mAavXm9UbuwA8Za7zAgGW0hpctb8TTQF6HmI08ZWg=
+github.com/blugnu/unilog v1.1.4 h1:s9vVAflgm4EdWI7wCdoAjdf1n3JgcWpORapHQuGVjM4=
+github.com/blugnu/unilog v1.1.4/go.mod h1:mNIz4qsIp/c8i0bwxlm3jErP+CopHlg5BCmbuhkgqOo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -15,8 +15,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
-golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
+golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
updates the dependency on `unilog` and replaces the indirect dependency on `blugnu/go-errorcontext` with `blugnu/errorcontext`.

also updates the action workflow to use the module release pipeline, rather than the truncated qa pipeline 